### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # HamlReloader
-[![Build Status](https://travis-ci.org/petermelias/hamlreloader.png?branch=master)](https://travis-ci.org/petermelias/hamlreloader) [![Coverage Status](https://coveralls.io/repos/petermelias/hamlreloader/badge.png?branch=master)](https://coveralls.io/r/petermelias/hamlreloader?branch=master) [![Downloads](https://pypip.in/d/hamlreloader/badge.png)](https://crate.io/packages/hamlreloader) [![Downloads](https://pypip.in/v/hamlreloader/badge.png)](https://crate.io/packages/hamlreloader)
+[![Build Status](https://travis-ci.org/petermelias/hamlreloader.png?branch=master)](https://travis-ci.org/petermelias/hamlreloader) [![Coverage Status](https://coveralls.io/repos/petermelias/hamlreloader/badge.png?branch=master)](https://coveralls.io/r/petermelias/hamlreloader?branch=master) [![Downloads](https://img.shields.io/pypi/dm/hamlreloader.svg)](https://crate.io/packages/hamlreloader) [![Downloads](https://img.shields.io/pypi/v/hamlreloader.svg)](https://crate.io/packages/hamlreloader)
 
 ## Usage
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20hamlreloader))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `hamlreloader`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.